### PR TITLE
Implement basic tuning engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,16 @@ Bb tuning
 	•	Save favorite tunings
 	•	AI-assisted tuning accuracy coach (stretch)
 
+## Quick Start
+
+Run the following commands after cloning:
+
+```bash
+flutter pub get
+flutter run
+```
+
+
 ⸻
 
 🤝 Contributing

--- a/lib/tuner_engine.dart
+++ b/lib/tuner_engine.dart
@@ -1,0 +1,32 @@
+import 'dart:async';
+import 'package:flutter_fft/flutter_fft.dart';
+import 'package:permission_handler/permission_handler.dart';
+
+class DetectedPitch {
+  final double frequency;
+
+  DetectedPitch(this.frequency);
+}
+
+class TunerEngine {
+  final FlutterFft _fft = FlutterFft();
+  final StreamController<DetectedPitch> _controller = StreamController.broadcast();
+
+  Stream<DetectedPitch> get onPitch => _controller.stream;
+
+  Future<void> start() async {
+    await Permission.microphone.request();
+    await _fft.startRecorder();
+    _fft.onRecorderStateChanged.listen((data) {
+      final freq = data[1];
+      if (freq is double && freq > 0) {
+        _controller.add(DetectedPitch(freq));
+      }
+    });
+  }
+
+  Future<void> stop() async {
+    await _fft.stopRecorder();
+    await _controller.close();
+  }
+}

--- a/lib/tuning.dart
+++ b/lib/tuning.dart
@@ -1,0 +1,36 @@
+import 'dart:math';
+
+class NoteMatch {
+  final String note;
+  final double targetFreq;
+  final double cents;
+
+  NoteMatch({required this.note, required this.targetFreq, required this.cents});
+}
+
+Map<String, double> standardGuitarTuning = {
+  'E2': 82.41,
+  'A2': 110.00,
+  'D3': 146.83,
+  'G3': 196.00,
+  'B3': 246.94,
+  'E4': 329.63,
+};
+
+NoteMatch matchFrequency(double freq, Map<String, double> tuning) {
+  String bestNote = tuning.keys.first;
+  double bestFreq = tuning[bestNote]!;
+  double minDiff = (freq - bestFreq).abs();
+
+  tuning.forEach((note, f) {
+    final diff = (freq - f).abs();
+    if (diff < minDiff) {
+      minDiff = diff;
+      bestNote = note;
+      bestFreq = f;
+    }
+  });
+
+  final cents = 1200 * (log(freq / bestFreq) / ln2);
+  return NoteMatch(note: bestNote, targetFreq: bestFreq, cents: cents);
+}

--- a/lib/widgets/tuning_dial.dart
+++ b/lib/widgets/tuning_dial.dart
@@ -1,0 +1,59 @@
+import 'dart:math';
+import 'package:flutter/material.dart';
+
+class TuningDial extends StatelessWidget {
+  final double cents;
+
+  const TuningDial({Key? key, required this.cents}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return CustomPaint(
+      painter: _DialPainter(cents),
+      size: const Size(200, 200),
+    );
+  }
+}
+
+class _DialPainter extends CustomPainter {
+  final double cents;
+
+  _DialPainter(this.cents);
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final center = size.center(Offset.zero);
+    final radius = size.width / 2;
+
+    final ringPaint = Paint()
+      ..color = Colors.grey.shade300
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 8;
+    canvas.drawCircle(center, radius, ringPaint);
+
+    final tickPaint = Paint()
+      ..color = Colors.grey
+      ..strokeWidth = 2;
+    for (int i = -5; i <= 5; i++) {
+      final angle = pi + (i / 5) * pi;
+      final inner = Offset(center.dx + cos(angle) * radius * 0.8,
+          center.dy + sin(angle) * radius * 0.8);
+      final outer = Offset(center.dx + cos(angle) * radius,
+          center.dy + sin(angle) * radius);
+      canvas.drawLine(inner, outer, tickPaint);
+    }
+
+    final needlePaint = Paint()
+      ..color = Colors.red
+      ..strokeWidth = 4;
+    final angle = pi + (cents.clamp(-50, 50) / 50) * pi;
+    final needle = Offset(center.dx + cos(angle) * radius * 0.75,
+        center.dy + sin(angle) * radius * 0.75);
+    canvas.drawLine(center, needle, needlePaint);
+  }
+
+  @override
+  bool shouldRepaint(covariant _DialPainter oldDelegate) {
+    return oldDelegate.cents != cents;
+  }
+}

--- a/main.dart
+++ b/main.dart
@@ -1,4 +1,7 @@
 import 'package:flutter/material.dart';
+import 'lib/tuner_engine.dart';
+import 'lib/tuning.dart';
+import 'lib/widgets/tuning_dial.dart';
 
 void main() {
   runApp(AllTuneApp());
@@ -21,27 +24,66 @@ class AllTuneApp extends StatelessWidget {
         scaffoldBackgroundColor: Colors.black,
       ),
       themeMode: ThemeMode.system,
-      home: HomeScreen(),
+      home: TunerScreen(),
     );
   }
 }
 
-class HomeScreen extends StatelessWidget {
-  const HomeScreen({super.key});
+class TunerScreen extends StatefulWidget {
+  @override
+  _TunerScreenState createState() => _TunerScreenState();
+}
+
+class _TunerScreenState extends State<TunerScreen> {
+  final TunerEngine _engine = TunerEngine();
+  double _frequency = 0.0;
+  NoteMatch? _match;
+
+  @override
+  void initState() {
+    super.initState();
+    _start();
+  }
+
+  Future<void> _start() async {
+    await _engine.start();
+    _engine.onPitch.listen((pitch) {
+      setState(() {
+        _frequency = pitch.frequency;
+        _match = matchFrequency(_frequency, standardGuitarTuning);
+      });
+    });
+  }
+
+  @override
+  void dispose() {
+    _engine.stop();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
+    final noteText = _match != null ? _match!.note : '--';
+    final cents = _match?.cents ?? 0;
     return Scaffold(
       appBar: AppBar(
         title: Text('🎵 AllTune'),
         centerTitle: true,
       ),
-      body: Center(
-        child: Text(
-          'Welcome to AllTune!\nStart tuning your instrument.',
-          textAlign: TextAlign.center,
-          style: Theme.of(context).textTheme.headlineSmall,
-        ),
+      body: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          TuningDial(cents: cents),
+          const SizedBox(height: 20),
+          Text(
+            '${_frequency.toStringAsFixed(2)} Hz',
+            style: Theme.of(context).textTheme.headlineSmall,
+          ),
+          Text(
+            noteText,
+            style: Theme.of(context).textTheme.headlineMedium,
+          ),
+        ],
       ),
     );
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,15 @@
+name: alltune
+description: Universal offline musical instrument tuning app.
+publish_to: 'none'
+
+environment:
+  sdk: '>=2.17.0 <3.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  permission_handler: ^10.2.0
+  flutter_fft: ^2.0.0
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
## Summary
- add Flutter pitch detection and microphone permission handling
- show analog tuning dial widget
- implement note matching helper for guitar tuning
- wire tuner engine into main app
- document how to run the Flutter app

## Testing
- `dart format -o none -l 120 main.dart lib` *(fails: dart not found)*
- `flutter analyze` *(fails: flutter not found)*

------
https://chatgpt.com/codex/tasks/task_e_68426a8e945c8320ae926a2f4a6b129e