### PR TITLE
Add settings screen and persist user prefs

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,21 +1,45 @@
 import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'screens/home_screen.dart';
 
-void main() {
-  runApp(const AllTuneApp());
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  final prefs = await SharedPreferences.getInstance();
+  final isDark = prefs.getBool('isDarkMode') ?? false;
+  runApp(AllTuneApp(isDarkMode: isDark));
 }
 
 /// Root widget for AllTune.
 /// Holds light/dark themes and routes to the HomeScreen.
-class AllTuneApp extends StatelessWidget {
-  const AllTuneApp({super.key});
+class AllTuneApp extends StatefulWidget {
+  final bool isDarkMode;
+  const AllTuneApp({super.key, required this.isDarkMode});
+
+  @override
+  State<AllTuneApp> createState() => _AllTuneAppState();
+}
+
+class _AllTuneAppState extends State<AllTuneApp> {
+  late ThemeMode _themeMode;
+
+  @override
+  void initState() {
+    super.initState();
+    _themeMode = widget.isDarkMode ? ThemeMode.dark : ThemeMode.light;
+  }
+
+  void _updateTheme(bool isDark) {
+    setState(() {
+      _themeMode = isDark ? ThemeMode.dark : ThemeMode.light;
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'AllTune',
       debugShowCheckedModeBanner: false,
-      themeMode: ThemeMode.system,
+      themeMode: _themeMode,
       theme: ThemeData(
         brightness: Brightness.light,
         primarySwatch: Colors.indigo,
@@ -26,7 +50,7 @@ class AllTuneApp extends StatelessWidget {
         primarySwatch: Colors.indigo,
         scaffoldBackgroundColor: Colors.black,
       ),
-      home: const HomeScreen(),
+      home: HomeScreen(onThemeChanged: _updateTheme),
     );
   }
 }

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,21 +1,79 @@
 import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'settings_screen.dart';
 
-class HomeScreen extends StatelessWidget {
-  const HomeScreen({super.key});
+class HomeScreen extends StatefulWidget {
+  final ValueChanged<bool> onThemeChanged;
+  const HomeScreen({super.key, required this.onThemeChanged});
+
+  @override
+  State<HomeScreen> createState() => _HomeScreenState();
+}
+
+class _HomeScreenState extends State<HomeScreen> {
+  final List<String> _instruments = ['Guitar', 'Violin', 'Ukulele'];
+  String _instrument = 'Guitar';
+  String _tuning = 'Standard';
+
+  @override
+  void initState() {
+    super.initState();
+    _loadPrefs();
+  }
+
+  Future<void> _loadPrefs() async {
+    final prefs = await SharedPreferences.getInstance();
+    setState(() {
+      _instrument = prefs.getString('instrument') ?? _instruments.first;
+      _tuning = prefs.getString('tuning') ?? 'Standard';
+    });
+  }
+
+  Future<void> _savePrefs() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString('instrument', _instrument);
+    await prefs.setString('tuning', _tuning);
+  }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text('🎵 AllTune'),
+        title: const Text('🎵 AllTune'),
         centerTitle: true,
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.settings),
+            onPressed: () {
+              Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (_) => SettingsScreen(
+                    onThemeChanged: widget.onThemeChanged,
+                  ),
+                ),
+              );
+            },
+          )
+        ],
       ),
-      body: Center(
-        child: Text(
-          'Welcome to AllTune!\nStart tuning your instrument.',
-          textAlign: TextAlign.center,
-          style: Theme.of(context).textTheme.headlineSmall,
-        ),
+      body: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          const Text('Select Instrument'),
+          DropdownButton<String>(
+            value: _instrument,
+            items: _instruments
+                .map((e) => DropdownMenuItem(value: e, child: Text(e)))
+                .toList(),
+            onChanged: (val) {
+              if (val == null) return;
+              setState(() => _instrument = val);
+              _savePrefs();
+            },
+          ),
+          const SizedBox(height: 16),
+          Text('Current Instrument: $_instrument'),
+        ],
       ),
     );
   }

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Basic settings screen with toggle options.
+class SettingsScreen extends StatefulWidget {
+  final ValueChanged<bool> onThemeChanged;
+  const SettingsScreen({Key? key, required this.onThemeChanged}) : super(key: key);
+
+  @override
+  State<SettingsScreen> createState() => _SettingsScreenState();
+}
+
+class _SettingsScreenState extends State<SettingsScreen> {
+  bool _showFrequency = true;
+  bool _showNoteName = true;
+  bool _isDarkMode = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadPrefs();
+  }
+
+  Future<void> _loadPrefs() async {
+    final prefs = await SharedPreferences.getInstance();
+    setState(() {
+      _showFrequency = prefs.getBool('showFrequency') ?? true;
+      _showNoteName = prefs.getBool('showNoteName') ?? true;
+      _isDarkMode = prefs.getBool('isDarkMode') ?? false;
+    });
+  }
+
+  Future<void> _updateBool(String key, bool value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(key, value);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Settings')),
+      body: ListView(
+        children: [
+          SwitchListTile(
+            title: const Text('Show Frequency'),
+            value: _showFrequency,
+            onChanged: (val) {
+              setState(() => _showFrequency = val);
+              _updateBool('showFrequency', val);
+            },
+          ),
+          SwitchListTile(
+            title: const Text('Show Note Name'),
+            value: _showNoteName,
+            onChanged: (val) {
+              setState(() => _showNoteName = val);
+              _updateBool('showNoteName', val);
+            },
+          ),
+          SwitchListTile(
+            title: const Text('Dark Theme'),
+            value: _isDarkMode,
+            onChanged: (val) {
+              setState(() => _isDarkMode = val);
+              _updateBool('isDarkMode', val);
+              widget.onThemeChanged(val);
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- persist last selected instrument and theme using `shared_preferences`
- build basic Settings screen with toggles for frequency, note name and theme
- hook up Settings screen and instrument dropdown on Home screen

## Testing
- `git status --short`
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68427bebfe4c8320b7bf5e2b0d8c6b40