### PR TITLE
Add themed dial widget and responsive UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@
 - 🔁 Swipe between instrument presets
 - 🎼 Alternate tunings (Drop D, DADGAD, Open G, etc.)
 - 🌙 Light & dark mode
+- 🔆 High-contrast fonts and large icons
+- ✨ Animated tuning feedback when in tune
 - 🧠 Designed for beginners and pros alike
 
 ---

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -12,22 +12,40 @@ class AllTuneApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final baseLight = ThemeData.light();
+    final baseDark = ThemeData.dark();
+
     return MaterialApp(
       title: 'AllTune',
       debugShowCheckedModeBanner: false,
       themeMode: ThemeMode.system,
-      theme: ThemeData(
-        brightness: Brightness.light,
-        primarySwatch: Colors.indigo,
+      theme: baseLight.copyWith(
+        colorScheme: baseLight.colorScheme.copyWith(
+          primary: Colors.deepPurple,
+          secondary: Colors.deepPurpleAccent,
+        ),
         scaffoldBackgroundColor: Colors.white,
+        textTheme: baseLight.textTheme.apply(fontSizeFactor: 1.2),
+        iconTheme: const IconThemeData(size: 32, color: Colors.deepPurple),
+        appBarTheme: const AppBarTheme(
+          backgroundColor: Colors.deepPurple,
+          foregroundColor: Colors.white,
+        ),
       ),
-      darkTheme: ThemeData(
-        brightness: Brightness.dark,
-        primarySwatch: Colors.indigo,
+      darkTheme: baseDark.copyWith(
+        colorScheme: baseDark.colorScheme.copyWith(
+          primary: Colors.deepPurpleAccent,
+          secondary: Colors.deepPurple,
+        ),
         scaffoldBackgroundColor: Colors.black,
+        textTheme: baseDark.textTheme.apply(fontSizeFactor: 1.2),
+        iconTheme: const IconThemeData(size: 32, color: Colors.white),
+        appBarTheme: const AppBarTheme(
+          backgroundColor: Colors.black,
+          foregroundColor: Colors.white,
+        ),
       ),
       home: const HomeScreen(),
     );
   }
 }
-

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,21 +1,68 @@
 import 'package:flutter/material.dart';
+import '../widgets/tuning_dial.dart';
 
-class HomeScreen extends StatelessWidget {
+class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});
+
+  @override
+  State<HomeScreen> createState() => _HomeScreenState();
+}
+
+class _HomeScreenState extends State<HomeScreen> {
+  double _cents = 0;
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text('🎵 AllTune'),
+        title: const Text('🎵 AllTune'),
         centerTitle: true,
       ),
-      body: Center(
-        child: Text(
-          'Welcome to AllTune!\nStart tuning your instrument.',
-          textAlign: TextAlign.center,
-          style: Theme.of(context).textTheme.headlineSmall,
-        ),
+      body: OrientationBuilder(
+        builder: (context, orientation) {
+          final dial = TuningDial(cents: _cents);
+          final slider = Slider(
+            value: _cents,
+            min: -50,
+            max: 50,
+            label: '${_cents.toStringAsFixed(0)}c',
+            onChanged: (v) => setState(() => _cents = v),
+          );
+
+          if (orientation == Orientation.portrait) {
+            return Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                dial,
+                const SizedBox(height: 32),
+                Text(
+                  'Pitch Offset: ${_cents.toStringAsFixed(1)} cents',
+                  style: Theme.of(context).textTheme.titleLarge,
+                ),
+                slider,
+              ],
+            );
+          } else {
+            return Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Expanded(child: Center(child: dial)),
+                Expanded(
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Text(
+                        'Pitch Offset: ${_cents.toStringAsFixed(1)} cents',
+                        style: Theme.of(context).textTheme.titleLarge,
+                      ),
+                      slider,
+                    ],
+                  ),
+                ),
+              ],
+            );
+          }
+        },
       ),
     );
   }

--- a/lib/widgets/tuning_dial.dart
+++ b/lib/widgets/tuning_dial.dart
@@ -1,0 +1,117 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+
+/// A simple analog-style tuning dial.
+/// [cents] should be in the range -50..50 representing pitch deviation.
+class TuningDial extends StatefulWidget {
+  final double cents;
+  const TuningDial({super.key, required this.cents});
+
+  @override
+  State<TuningDial> createState() => _TuningDialState();
+}
+
+class _TuningDialState extends State<TuningDial>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller =
+        AnimationController(vsync: this, duration: const Duration(seconds: 1));
+  }
+
+  @override
+  void didUpdateWidget(covariant TuningDial oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // When pitch is nearly in tune, show a pulsing glow.
+    if (widget.cents.abs() < 3) {
+      if (!_controller.isAnimating) {
+        _controller.repeat(reverse: true);
+      }
+    } else {
+      _controller.stop();
+      _controller.value = 0;
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: _controller,
+      builder: (context, child) {
+        return Container(
+          width: 200,
+          height: 200,
+          decoration: BoxDecoration(
+            shape: BoxShape.circle,
+            boxShadow: [
+              if (widget.cents.abs() < 3)
+                BoxShadow(
+                  color: Colors.green.withOpacity(0.6 * _controller.value),
+                  blurRadius: 20 * _controller.value + 10,
+                  spreadRadius: 2 * _controller.value,
+                ),
+            ],
+          ),
+          child: CustomPaint(
+            painter: _DialPainter(widget.cents),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _DialPainter extends CustomPainter {
+  final double cents;
+  _DialPainter(this.cents);
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final center = size.center(Offset.zero);
+    final radius = size.width / 2;
+
+    final circlePaint = Paint()
+      ..color = Colors.grey.shade400
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 6;
+    canvas.drawCircle(center, radius, circlePaint);
+
+    // Draw scale marks.
+    final markPaint = Paint()
+      ..color = Colors.grey.shade600
+      ..strokeWidth = 2;
+    for (int i = -5; i <= 5; i++) {
+      final angle = (i / 10) * math.pi + math.pi / 2;
+      final start = Offset(center.dx + radius * 0.8 * math.cos(angle),
+          center.dy + radius * 0.8 * math.sin(angle));
+      final end = Offset(center.dx + radius * math.cos(angle),
+          center.dy + radius * math.sin(angle));
+      canvas.drawLine(start, end, markPaint);
+    }
+
+    // Draw indicator needle.
+    final indicatorPaint = Paint()
+      ..color = Colors.deepPurple
+      ..strokeWidth = 4
+      ..strokeCap = StrokeCap.round;
+    final clamped = cents.clamp(-50, 50) as double;
+    final angle = (clamped / 100) * math.pi + math.pi / 2;
+    final end = Offset(center.dx + radius * 0.75 * math.cos(angle),
+        center.dy + radius * 0.75 * math.sin(angle));
+    canvas.drawLine(center, end, indicatorPaint);
+  }
+
+  @override
+  bool shouldRepaint(covariant _DialPainter oldDelegate) =>
+      oldDelegate.cents != cents;
+}


### PR DESCRIPTION
## Summary
- set up modern light and dark themes with larger fonts and icons
- implement a `TuningDial` widget with glowing animation
- update `HomeScreen` to be responsive and show the dial
- document new accessibility and animation features

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68427bd01e408320a0a3b0cf11299421